### PR TITLE
Add email to drupaltestuser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 ; Composer
 vendor
 composer.lock
+
+; PhpStorm
+.idea

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ modules:
             url: 'http://localhost/myapp/'
         DrupalUserRegistry:
             roles: ['administrator', 'editor', 'sub editor', 'lowly-user', 'authenticated']  # A list of user roles.
+            emails:
+                - administrator: 'admin@example.com'
+                - editor: 'editor@example.com'
             password: 'test123!'         # The password to use for all test users.
             create: true                 # Whether to create all defined test users at the start of the suite.
             delete: true                 # Whether to delete all defined test users at the end of the suite.

--- a/src/Drupal/UserRegistry/DrupalTestUser.php
+++ b/src/Drupal/UserRegistry/DrupalTestUser.php
@@ -22,6 +22,13 @@ class DrupalTestUser
     public $pass;
 
     /**
+     * The email address for this user's account.
+     *
+     * @var string
+     */
+    public $email;
+
+    /**
      * @var null|string
      *   The role that this user should be given.
      */
@@ -36,12 +43,15 @@ class DrupalTestUser
      *   The password for this user's account.
      * @param string|null $roleName
      *   The role that this user should be given.
+     * @param string|null $email
+     *   The email address that this user should be given.
      */
-    public function __construct($name, $pass, $roleName = null)
+    public function __construct($name, $pass, $roleName = null, $email = null)
     {
         $this->name = $name;
         $this->pass = $pass;
         $this->roleName = $roleName;
+        $this->email = $email;
     }
 
     /**

--- a/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
+++ b/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
@@ -52,7 +52,7 @@ class ModuleConfigStorage implements StorageInterface
     public function __construct($config)
     {
         $this->roles = $config['roles'];
-        $this->emails = $config['emails'][0];
+        $this->emails = isset($config['emails'][0]) ? $config['emails'][0] : array();
         $this->password = $config['password'];
     }
 

--- a/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
+++ b/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
@@ -52,7 +52,7 @@ class ModuleConfigStorage implements StorageInterface
     public function __construct($config)
     {
         $this->roles = $config['roles'];
-        $this->emails = $config['emails'];
+        $this->emails = $config['emails'][0];
         $this->password = $config['password'];
     }
 

--- a/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
+++ b/src/Drupal/UserRegistry/Storage/ModuleConfigStorage.php
@@ -37,6 +37,13 @@ class ModuleConfigStorage implements StorageInterface
     protected $password;
 
     /**
+     * Indexed array of email addresses, where the key is the role name.
+     *
+     * @var string
+     */
+    protected $emails;
+
+    /**
      * Check for required module configuration and initialize.
      *
      * @param array $config
@@ -45,6 +52,7 @@ class ModuleConfigStorage implements StorageInterface
     public function __construct($config)
     {
         $this->roles = $config['roles'];
+        $this->emails = $config['emails'];
         $this->password = $config['password'];
     }
 
@@ -59,7 +67,11 @@ class ModuleConfigStorage implements StorageInterface
             function ($roleName) {
                 $roleNameSuffix = preg_replace(self::DRUPAL_ROLE_TO_USERNAME_PATTERN, ".", $roleName);
                 $userName = self::DRUPAL_USERNAME_PREFIX . "." . $roleNameSuffix;
-                return new DrupalTestUser($userName, $this->password, $roleName);
+
+                // If an email address has been provided, set one.
+                $email = isset($this->emails[$roleName]) ? $this->emails[$roleName] : null;
+
+                return new DrupalTestUser($userName, $this->password, $roleName, $email);
             },
             array_combine($this->roles, $this->roles)
         );

--- a/src/DrupalUserRegistry.php
+++ b/src/DrupalUserRegistry.php
@@ -26,6 +26,9 @@ use Codeception\Module\Drupal\UserRegistry\Storage\StorageInterface;
  *             url: 'http://localhost/myapp/'
  *         DrupalUserRegistry:
  *             roles: ['administrator', 'editor', 'sub editor', 'lowly-user', 'authenticated']  # A list of user roles.
+ *             emails: # A list of emails for each role. Not all roles need to have emails.
+ *               - administrator: 'admin@example.com'
+ *               - editor: 'editor@example.com'
  *             password: 'test123!'         # The password to use for all test users.
  *             create: true                 # Whether to create all defined test users at the start of the suite.
  *             delete: true                 # Whether to delete all defined test users at the end of the suite.


### PR DESCRIPTION
Hi Paul,

We're currently using Codeception with your excellent DrupalUserRegistry module. However, we're integrating with a third party system that uses emails and not usernames to log in.

My helper class does the conversion, but I need to be able to store and retrieve an email address from the DrupalTestUser object, which isn't currently possible.

Here is a quick change, but don't worry, it's all optional, so if you don't put email in your YAML file, it won't use it at all.

Because it's me, all the documentation should there as well. ;)